### PR TITLE
Fix README.md Missing Code Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Git-and-GitHub-Seminar
-Supporting documents and information for the Git and GitHub seminar
 
+Supporting documents and information for the Git and GitHub seminar.
 
 1. Clone das repository nak-repo eines anderen Teilnehmers 
    in das eigene lokale Verzeichnis nak-task
 
+   ```bash
    ~/projects $ git clone https://github.com/NakTNYyyXxx/nak-repo.git nak-task
    
    Cloning into 'nak-task'...
@@ -13,6 +14,7 @@ Supporting documents and information for the Git and GitHub seminar
    
    ~/projects $ cd nak-task
    ~/projects/nak-task (master) $
+   ```
    
 2. Gegenseitige Berechtigung als Collaborator
 


### PR DESCRIPTION
Hey! I noticed that the `README.md` has a few commands in the first task. IMO it's better when commands are in code blocks (as most terminals also have monospace fonts).

This PR adds a code segment around the git commands.